### PR TITLE
Add the ability to get a packed ref if the branchPath does not exist

### DIFF
--- a/tests/fixtures/commit-packed/dot-git/HEAD
+++ b/tests/fixtures/commit-packed/dot-git/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/develop

--- a/tests/fixtures/commit-packed/dot-git/packed-refs
+++ b/tests/fixtures/commit-packed/dot-git/packed-refs
@@ -1,0 +1,5 @@
+5359aabd3872d9ffd160712e9615c5592dfe6745 refs/remotes/origin/master
+d670460b4b4aece5915caf5c68d12f560a9fe3e4 refs/heads/develop
+c76753aa8651471fe082a3ecd0790ec54f5ec673 refs/tags/v1.0.0
+5359aabd3872d9ffd160712e9615c5592dfe6745 refs/tags/my-tag
+6f2abfab299ad8e302f3a3023f88483f4be3b402 refs/tags/v1.0.1

--- a/tests/index.js
+++ b/tests/index.js
@@ -92,6 +92,20 @@ describe('git-repo-info', function() {
       assert.deepEqual(result, expected);
     });
 
+    it('returns an object with repo info (packed commit)', function() {
+      var repoRoot = path.join(testFixturesPath, 'commit-packed');
+      var result = repoInfo(path.join(repoRoot, gitDir));
+
+      var expected = {
+        branch: 'develop',
+        sha: 'd670460b4b4aece5915caf5c68d12f560a9fe3e4',
+        abbreviatedSha: 'd670460b4b',
+        tag: null,
+        root: repoRoot
+      };
+
+      assert.deepEqual(result, expected);
+    });
 
     it('returns an object with repo info, including the tag (packed tags)', function() {
       var repoRoot = path.join(testFixturesPath, 'tagged-commit-packed');


### PR DESCRIPTION
I have been having an issue lately where circle ci has changed their config and the branchPath no longer exists. After talking with their support they told me to use the packed-ref sha instead.

This is related to #17 and #16 
