### PR TITLE
Do not call path.resolve when no git path is found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,10 +125,14 @@ module.exports = function(gitPath) {
     abbreviatedSha: null,
     branch: null,
     tag: null,
-    root: path.resolve(gitPath, '..')
+    root: null
   };
 
+  if (!gitPath) { return result; }
+
   try {
+    result.root = path.resolve(gitPath, '..');
+
     var headFilePath   = path.join(gitPath, 'HEAD');
 
     if (fs.existsSync(headFilePath)) {


### PR DESCRIPTION
Fixes #19.
