### PR TITLE
Fix no .git commondir in submodule repos

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,9 @@ function findRepoHandleLinkedWorktree(gitPath) {
     var linkedGitDir = fs.readFileSync(gitPath).toString();
     var worktreeGitDir = /gitdir: (.*)/.exec(linkedGitDir)[1];
     var commonDirPath = path.join(worktreeGitDir, 'commondir');
-    var commonDirRelative = fs.readFileSync(commonDirPath).toString().replace(/\r?\n$/, '');
-    var commonDir = path.resolve(path.join(worktreeGitDir, commonDirRelative));
+    var commonDirRelative = fs.existsSync(commonDirPath) &&
+                          fs.readFileSync(commonDirPath).toString().replace(/\r?\n$/, '');
+    var commonDir = commonDirPath && path.resolve(path.join(worktreeGitDir, commonDirRelative));
 
     return {
       worktreeGitDir: path.resolve(worktreeGitDir),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-repo-info",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Retrieve current sha and branch name from a git repo.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Hi, there.

I found v0.13.0 breaks in a submodule repo.
same as https://github.com/rwjblue/git-repo-info/issues/27
and https://github.com/TryGhost/Ghost/issues/7614

Recently, I installed Ghost with a developer install,

When I run `grunt init`, it returns 

```
>> Ran "grunt init" in "core/client".

Running "clean:tmp" (clean) task
>> 0 paths cleaned.

Running "subgrunt:dev" (subgrunt) task
Running "shell:ember:dev" (shell) task

> ghost-admin@1.0.0-alpha.5 build /Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client
> ember build

ENOENT: no such file or directory, open '../../.git/modules/core/client/commondir'
Error: ENOENT: no such file or directory, open '../../.git/modules/core/client/commondir'
    at Error (native)
    at Object.fs.openSync (fs.js:549:18)
    at Object.fs.readFileSync (fs.js:397:15)
    at findRepoHandleLinkedWorktree (/Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client/node_modules/git-repo-info/index.js:27:32)
    at findRepo (/Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client/node_modules/git-repo-info/index.js:47:14)
    at module.exports (/Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client/node_modules/git-repo-info/index.js:145:21)
    at version (/Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client/node_modules/git-repo-version/index.js:11:14)
    at CoreObject.module.exports.config (/Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client/node_modules/ember-cli-app-version/index.js:10:46)
    at CoreObject.superWrapper [as config] (/Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client/node_modules/core-object/lib/assign-properties.js:32:18)
    at /Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client/node_modules/ember-cli/lib/models/project.js:224:29

npm ERR! Darwin 16.0.0
npm ERR! argv "/usr/local/bin/node" "/Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client/node_modules/.bin/npm" "run" "build"
npm ERR! node v4.2.1
npm ERR! npm  v2.15.5
npm ERR! code ELIFECYCLE
npm ERR! ghost-admin@1.0.0-alpha.5 build: `ember build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the ghost-admin@1.0.0-alpha.5 build script 'ember build'.
npm ERR! This is most likely a problem with the ghost-admin package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     ember build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs ghost-admin
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!
npm ERR!     npm owner ls ghost-admin
npm ERR! There is likely additional logging output above.
```

That sounds strange, so I dug in and found
https://github.com/ember-cli/ember-cli/blob/master/lib/utilities/version-utils.js#L5

Ghost requires Ghost-Admin, Ghost-Admin requires ember-cli, 
and finally, ember-cli  requires this repo.

If there is a submodule repo,  in this [PR](https://github.com/rwjblue/git-repo-info/pull/26) `commondir` may not exists.

So I just added some conditions and fix the problem.

```
>> Ran "grunt init" in "core/client".

Running "clean:tmp" (clean) task
>> 0 paths cleaned.

Running "subgrunt:dev" (subgrunt) task
Running "shell:ember:dev" (shell) task

> ghost-admin@1.0.0-alpha.5 build /Users/zhangbinliu/my_web_dev/Cool4zbl.com/myDevGhost/core/client
> ember build

Built project successfully. Stored in "dist/".

Done.
>> Ran "grunt shell:ember:dev" in "core/client".

Done.
```

However, there's already a [PR for SHA of a submodule](https://github.com/rwjblue/git-repo-info/pull/11) (also a better solution), 
the condition that if the file exists should be considered.

@rwjblue 
Please review, thanks.
