### PR TITLE
Add Git metadata directories to returned object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ info.committerDate        // commit date for the current sha
 info.author               // author for the current sha
 info.authorDate           // authored date for the current sha
 info.commitMessage        // commit message for the current sha
+info.root                 // root directory for the Git repo or submodule
+                          //   (if in a worktree, this is the directory containing the original copy)
+info.commonGitDir         // directory containing Git metadata for this repo or submodule
+                          //   (if in a worktree, this is the primary Git directory for the repo)
+info.worktreeGitDir       // if in a worktree, the directory containing Git metadata specific to
+                          //   this worktree; otherwise, this is the same as `commonGitDir`.
 ```
 
 When called without any arguments, `git-repo-info` will automatically lookup upwards

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,43 @@
+declare function gitRepoInfo(): gitRepoInfo.GitRepoInfo;
+
+declare namespace gitRepoInfo {
+  export interface GitRepoInfo {
+    /** The current branch */
+    branch: string;
+    /** SHA of the current commit */
+    sha: string;
+    /** The first 10 chars of the current SHA */
+    abbreviatedSha: string;
+    /** The tag for the current SHA (or `null` if no tag exists) */
+    tag: string | null;
+    /** Tag for the closest tagged ancestor (or `null` if no ancestor is tagged) */
+    lastTag: string | null;
+    /** The committer of the current SHA */
+    committer: string;
+    /** The commit date of the current SHA */
+    committerDate: string;
+    /** The author for the current SHA */
+    author: string;
+    /** The authored date for the current SHA */
+    authorDate: string;
+    /** The commit message for the current SHA */
+    commitMessage: string;
+    /**
+     * The root directory for the Git repo or submodule.
+     * If in a worktree, this is the directory containing the original copy, not the worktree.
+     */
+    root: string;
+    /**
+    * The directory containing Git metadata for this repo or submodule.
+    * If in a worktree, this is the primary Git directory for the repo, not the worktree-specific one.
+    */
+    commonGitDir: string;
+    /**
+     * If in a worktree, the directory containing Git metadata specific to this worktree.
+     * Otherwise, this is the same as `commonGitDir`.
+     */
+    worktreeGitDir: string;
+  }
+}
+
+export = gitRepoInfo;

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.0",
   "description": "Retrieve current sha and branch name from a git repo.",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "mocha tests",
@@ -25,8 +27,8 @@
   },
   "homepage": "https://github.com/rwjblue/git-repo-info",
   "devDependencies": {
-    "mocha": "^1.21.4",
-    "mocha-jshint": "^1.1.0"
+    "mocha": "^4.1.0",
+    "mocha-jshint": "^2.3.1"
   },
   "engines": {
     "node": ">= 4.0"

--- a/tests/index.js
+++ b/tests/index.js
@@ -32,6 +32,7 @@ describe('git-repo-info', function() {
       assert.deepEqual(foundPathInfo, {
         worktreeGitDir: path.join(repoRoot, gitDir),
         commonGitDir: path.join(repoRoot, gitDir),
+        root: repoRoot,
       });
     });
 
@@ -42,6 +43,7 @@ describe('git-repo-info', function() {
       assert.deepEqual(foundPathInfo, {
         worktreeGitDir: path.join(repoRoot, gitDir),
         commonGitDir: path.join(repoRoot, gitDir),
+        root: repoRoot,
       });
     });
 
@@ -52,6 +54,7 @@ describe('git-repo-info', function() {
       assert.deepEqual(foundPathInfo, {
         worktreeGitDir: path.join(repoRoot, gitDir),
         commonGitDir: path.join(repoRoot, gitDir),
+        root: repoRoot,
       });
     });
 
@@ -62,6 +65,7 @@ describe('git-repo-info', function() {
       assert.deepEqual(foundPathInfo, {
         worktreeGitDir: path.join(repoRoot, gitDir),
         commonGitDir: path.join(repoRoot, gitDir),
+        root: repoRoot,
       });
     });
 
@@ -72,16 +76,19 @@ describe('git-repo-info', function() {
       assert.deepEqual(foundPathInfo, {
         worktreeGitDir: path.join(repoRoot, gitDir),
         commonGitDir: path.join(repoRoot, gitDir),
+        root: repoRoot,
       });
     });
 
     it('finds a repo via a linked worktree', function() {
-      process.chdir(path.join(testFixturesPath, 'linked-worktree', 'linked'));
+      var worktreeRoot = path.join(testFixturesPath, 'linked-worktree', 'linked');
+      process.chdir(worktreeRoot);
 
       var foundPathInfo = repoInfo._findRepo();
       assert.deepEqual(foundPathInfo, {
         worktreeGitDir: path.join(testFixturesPath, 'linked-worktree', 'dot-git', 'worktrees', 'linked'),
         commonGitDir: path.join(testFixturesPath, 'linked-worktree', 'dot-git'),
+        root: path.join(testFixturesPath, 'linked-worktree'),
       });
     });
 
@@ -92,6 +99,7 @@ describe('git-repo-info', function() {
       assert.deepEqual(foundPathInfo, {
         worktreeGitDir: path.join(testFixturesPath, 'submodule', 'dot-git', 'modules', 'my-submodule'),
         commonGitDir: path.join(testFixturesPath, 'submodule', 'dot-git', 'modules', 'my-submodule'),
+        root: path.join(testFixturesPath, 'submodule', 'my-submodule'),
       });
     });
 
@@ -102,6 +110,7 @@ describe('git-repo-info', function() {
         assert.deepEqual(foundPathInfo, {
           worktreeGitDir: path.join(testFixturesPath, 'submodule', 'dot-git', 'modules', 'my-submodule'),
           commonGitDir: path.join(testFixturesPath, 'submodule', 'dot-git', 'modules', 'my-submodule'),
+          root: path.join(testFixturesPath, 'submodule', 'my-submodule'),
         });
       });
   });
@@ -109,7 +118,8 @@ describe('git-repo-info', function() {
   describe('repoInfo', function() {
     it('returns an object with repo info', function() {
       var repoRoot = path.join(testFixturesPath, 'nested-repo');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: 'master',
@@ -122,6 +132,8 @@ describe('git-repo-info', function() {
         authorDate: null,
         commitMessage: null,
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         lastTag: null,
         commitsSinceLastTag: Infinity
       };
@@ -131,7 +143,8 @@ describe('git-repo-info', function() {
 
     it('returns an object with repo info including the parent tag', function() {
       var repoRoot = path.join(testFixturesPath, 'tag-on-parent');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: 'master',
@@ -144,6 +157,8 @@ describe('git-repo-info', function() {
         authorDate: '2017-10-14T02:02:43.000Z',
         commitMessage: 'second commit without tag',
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         parents: [
           'e66f7ec2da3b5d06f0fe845c4fbc87247efacf62'
         ],
@@ -156,7 +171,8 @@ describe('git-repo-info', function() {
 
     it('returns an object with repo info including the parent tag before a merge commit', function() {
       var repoRoot = path.join(testFixturesPath, 'tag-on-parent-before-merge');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: 'master',
@@ -169,6 +185,8 @@ describe('git-repo-info', function() {
         authorDate: '2017-11-13T14:54:49.000Z',
         commitMessage: 'merge red and blue',
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         parents: [
           '4f5c726a1528fdfb1ec7c9537e4b1b2dbaacbcc4'
         ],
@@ -181,7 +199,8 @@ describe('git-repo-info', function() {
 
     it('returns an object with repo info', function() {
       var repoRoot = path.join(testFixturesPath, 'detached-head');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: null,
@@ -194,6 +213,8 @@ describe('git-repo-info', function() {
         authorDate: null,
         commitMessage: null,
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         lastTag: null,
         commitsSinceLastTag: Infinity
       };
@@ -203,7 +224,8 @@ describe('git-repo-info', function() {
 
     it('returns an object with repo info (packed commit)', function() {
       var repoRoot = path.join(testFixturesPath, 'commit-packed');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: 'develop',
@@ -216,6 +238,8 @@ describe('git-repo-info', function() {
         authorDate: null,
         commitMessage: null,
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         lastTag: null,
         commitsSinceLastTag: Infinity
       };
@@ -225,7 +249,8 @@ describe('git-repo-info', function() {
 
     it('returns an object with repo info, including the tag (packed tags)', function() {
       var repoRoot = path.join(testFixturesPath, 'tagged-commit-packed');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: 'master',
@@ -238,6 +263,8 @@ describe('git-repo-info', function() {
         authorDate: null,
         commitMessage: null,
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         lastTag: 'my-tag',
         commitsSinceLastTag: 0
       };
@@ -247,7 +274,8 @@ describe('git-repo-info', function() {
 
     it('returns an object with repo info, including the tag (packed annotated tag)', function() {
       var repoRoot = path.join(testFixturesPath, 'tagged-commit-packed-annotated');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: 'master',
@@ -260,6 +288,8 @@ describe('git-repo-info', function() {
         authorDate: null,
         commitMessage: null,
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         lastTag: 'example-annotated-tag',
         commitsSinceLastTag: 0
       };
@@ -270,7 +300,8 @@ describe('git-repo-info', function() {
     if (zlib.inflateSync) {
       it('returns an object with repo info, including the tag (unpacked tags)', function() {
         var repoRoot = path.join(testFixturesPath, 'tagged-commit-unpacked');
-        var result = repoInfo(path.join(repoRoot, gitDir));
+        var localGitDir = path.join(repoRoot, gitDir);
+        var result = repoInfo(localGitDir);
 
         var expected = {
           branch: 'master',
@@ -283,6 +314,8 @@ describe('git-repo-info', function() {
           authorDate: '2015-04-15T12:10:06.000Z',
           commitMessage: 'Initial commit.',
           root: repoRoot,
+          commonGitDir: localGitDir,
+          worktreeGitDir: localGitDir,
           lastTag: 'awesome-tag',
           commitsSinceLastTag: 0
         };
@@ -292,7 +325,8 @@ describe('git-repo-info', function() {
     } else {
       it('returns an object with repo info, including the tag (unpacked tags)', function() {
         var repoRoot = path.join(testFixturesPath, 'tagged-commit-unpacked');
-        var result = repoInfo(path.join(repoRoot, gitDir));
+        var localGitDir = path.join(repoRoot, gitDir);
+        var result = repoInfo(localGitDir);
 
         var expected = {
           branch: 'master',
@@ -305,6 +339,8 @@ describe('git-repo-info', function() {
           authorDate: null,
           commitMessage: null,
           root: repoRoot,
+          commonGitDir: localGitDir,
+          worktreeGitDir: localGitDir,
           lastTag: 'awesome-tag',
           commitsSinceLastTag: 0
         };
@@ -315,7 +351,8 @@ describe('git-repo-info', function() {
 
     it('returns an object with repo info, including the tag (unpacked tags) when a tag object does not exist', function() {
       var repoRoot = path.join(testFixturesPath, 'tagged-commit-unpacked-no-object');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: 'master',
@@ -328,6 +365,8 @@ describe('git-repo-info', function() {
         authorDate: null,
         commitMessage: null,
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         lastTag: 'awesome-tag',
         commitsSinceLastTag: 0
       };
@@ -350,7 +389,8 @@ describe('git-repo-info', function() {
     if (zlib.inflateSync) {
       it('returns an object with repo info, including the tag (annotated tags)', function() {
         var repoRoot = path.join(testFixturesPath, 'tagged-annotated');
-        var result = repoInfo(path.join(repoRoot, gitDir));
+        var localGitDir = path.join(repoRoot, gitDir);
+        var result = repoInfo(localGitDir);
 
         var expected = {
           branch: 'master',
@@ -363,6 +403,8 @@ describe('git-repo-info', function() {
           authorDate: '2015-04-15T12:10:06.000Z',
           commitMessage: 'Initial commit.',
           root: repoRoot,
+          commonGitDir: localGitDir,
+          worktreeGitDir: localGitDir,
           lastTag: 'awesome-tag',
           commitsSinceLastTag: 0
         };
@@ -373,7 +415,8 @@ describe('git-repo-info', function() {
 
     it('returns an object with repo info, including the full branch name, if the branch name includes any slashes', function() {
       var repoRoot = path.join(testFixturesPath, 'branch-with-slashes');
-      var result = repoInfo(path.join(repoRoot, gitDir));
+      var localGitDir = path.join(repoRoot, gitDir);
+      var result = repoInfo(localGitDir);
 
       var expected = {
         branch: 'feature/branch/with/slashes',
@@ -386,6 +429,8 @@ describe('git-repo-info', function() {
         authorDate: null,
         commitMessage: null,
         root: repoRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         lastTag: null,
         commitsSinceLastTag: Infinity
       };
@@ -394,7 +439,8 @@ describe('git-repo-info', function() {
     });
 
     it('returns an object with repo info for linked worktrees', function() {
-      process.chdir(path.join(testFixturesPath, 'linked-worktree', 'linked'));
+      var repoRoot = path.join(testFixturesPath, 'linked-worktree');
+      process.chdir(path.join(repoRoot, 'linked'));
       var result = repoInfo();
 
       var expected = {
@@ -407,7 +453,9 @@ describe('git-repo-info', function() {
         author: null,
         authorDate: null,
         commitMessage: null,
-        root: path.join(testFixturesPath, 'linked-worktree'),
+        root: repoRoot,
+        commonGitDir: path.join(repoRoot, gitDir),
+        worktreeGitDir: path.join(repoRoot, gitDir, 'worktrees', 'linked'),
         lastTag: null,
         commitsSinceLastTag: Infinity
       };
@@ -416,8 +464,36 @@ describe('git-repo-info', function() {
     });
 
     it('returns an object for repo info for submodules', function() {
-      process.chdir(path.join(testFixturesPath, 'submodule', 'my-submodule'));
+      var parentRoot = path.join(testFixturesPath, 'submodule');
+      var moduleRoot = path.join(parentRoot, 'my-submodule');
+      var localGitDir = path.join(parentRoot, gitDir, 'modules', 'my-submodule');
+      process.chdir(moduleRoot);
       var result = repoInfo();
+      var expected = {
+        branch: null,
+        sha: '409372f3bd07c11bfacee3963f48571d675268d7',
+        abbreviatedSha: '409372f3bd',
+        tag: null,
+        committer: null,
+        committerDate: null,
+        author: null,
+        authorDate: null,
+        commitMessage: null,
+        root: moduleRoot,
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
+        lastTag: null,
+        commitsSinceLastTag: Infinity
+      };
+
+      assert.deepEqual(result, expected);
+    });
+
+    it('returns an object for repo info for submodule on a specific path', function() {
+      var parentRoot = path.join(testFixturesPath, 'submodule');
+      var localGitDir = path.join(parentRoot, gitDir, 'modules', 'my-submodule');
+      process.chdir(parentRoot);
+      var result = repoInfo('my-submodule');
 
       var expected = {
         branch: null,
@@ -429,41 +505,15 @@ describe('git-repo-info', function() {
         author: null,
         authorDate: null,
         commitMessage: null,
-        // This is a pretty meaningless "root" path.  The other information is
-        // correct, but we do not have full support for submodules at the
-        // moment.
-        root: path.join(testFixturesPath, 'submodule', 'dot-git', 'modules'),
+        root: path.join(parentRoot, 'my-submodule'),
+        commonGitDir: localGitDir,
+        worktreeGitDir: localGitDir,
         lastTag: null,
         commitsSinceLastTag: Infinity
       };
 
       assert.deepEqual(result, expected);
     });
-
-    it('returns an object for repo info for submodule on a specific path', function() {
-        process.chdir(path.join(testFixturesPath, 'submodule'));
-        var result = repoInfo('my-submodule');
-
-        var expected = {
-          branch: null,
-          sha: '409372f3bd07c11bfacee3963f48571d675268d7',
-          abbreviatedSha: '409372f3bd',
-          tag: null,
-          committer: null,
-          committerDate: null,
-          author: null,
-          authorDate: null,
-          commitMessage: null,
-          // This is a pretty meaningless "root" path.  The other information is
-          // correct, but we do not have full support for submodules at the
-          // moment.
-          root: path.join(testFixturesPath, 'submodule', 'dot-git', 'modules'),
-          lastTag: null,
-          commitsSinceLastTag: Infinity
-        };
-
-        assert.deepEqual(result, expected);
-      });
   });
 
   describe('repoInfo().root', function() {
@@ -477,6 +527,5 @@ describe('git-repo-info', function() {
     it('finds a repo with an argument', function() {
       assert.equal(repoInfo(path.join(repoRoot, 'foo', 'bar')).root, repoRoot);
     });
-
   });
 });


### PR DESCRIPTION
I have a scenario where I need to know the Git metadata directory for a local copy overall, as well as for a specific worktree. Those directories (`commonGitDir` and `worktreeGitDir`) are already calculated while getting repo info, so this PR adds them to the returned object.

This change also improves submodule support by returning the actual `root` (defined as the directory containing the `.git` folder/file) from `findRepoHandleLinkedWorktree` and using that in the returned object. For example, `root` in the returned object will now be `<repo root>/my-submodule` rather than something useless like `<repo root>/.git/modules`.

Other changes:
- Add a typings file (`index.d.ts`) for TypeScript users. If you prefer, this could be checked into DefinitelyTyped instead and made available as an `@types` package (having the typings bundled with the package itself is just a bit more convenient and makes them easier to update).
- Update dependency versions to get rid of security warnings displayed by npm 6
- Make the tests work on Windows by checking for `\r\n` newlines (in addition to `\n`) when processing objects