### PR TITLE
Add argument for main export to the type definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare function gitRepoInfo(): gitRepoInfo.GitRepoInfo;
+declare function gitRepoInfo(gitPath?: string): gitRepoInfo.GitRepoInfo;
 
 declare namespace gitRepoInfo {
   export interface GitRepoInfo {


### PR DESCRIPTION
The default export have gitPath arg and my CI failure when I upgraded to 2.1.0 