### PR TITLE
Ensure all parents are populated (e.g. merge commits have multiple references in `.parents`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,7 +322,10 @@ function getCommitData(gitPath, sha) {
             }
             break;
           case 'parent':
-            data.parents = section.split(/\r?\n/).map(p => p.split(' ')[1]);
+            if (!data.parents) {
+              data.parents = [];
+            }
+            data.parents.push(section.split(' ')[1]);
             break;
           default:
             //should just be the commit message left

--- a/tests/index.js
+++ b/tests/index.js
@@ -188,6 +188,7 @@ describe('git-repo-info', function() {
         commonGitDir: localGitDir,
         worktreeGitDir: localGitDir,
         parents: [
+          'b0c8b86ee451a2f389eed64838449d9a00a0b45f',
           '4f5c726a1528fdfb1ec7c9537e4b1b2dbaacbcc4'
         ],
         lastTag: 'magic-tag',


### PR DESCRIPTION
Parents are not read correctly
Closes #49 