### PR TITLE
Skip already seen commits in findLastTag

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,8 +168,13 @@ function findLastTagCached(gitPath, sha) {
 
 function findLastTag(gitPath, sha) {
   var queue = [{ sha: sha, depth: 0 }];
+  var seenCommits = new Set();
   while (queue.length) {
     var element = queue.shift();
+    if (seenCommits.has(element.sha)) {
+      continue;
+    }
+    seenCommits.add(element.sha);
     var tag = findTag(gitPath, element.sha);
     if (tag) {
       return {


### PR DESCRIPTION
Closes #54 

This should improve the performance for repositories with large number of merge commits, while not having a huge impact on other repositories (as set operations are fast).
I tested this on my company's repository with ~6000 commits. Execution time was improved from 10s to 4s. 