### PR TITLE
Allow Multiline Commit Messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,9 +336,9 @@ function getCommitData(gitPath, sha) {
           default:
             //should just be the commit message left
             if (!data.commitMessage) {
-              data.commitMessage = section
+              data.commitMessage = section;
             } else {
-              data.commitMessage = `${data.commitMessage}\n${section}`
+              data.commitMessage = `${data.commitMessage}\n${section}`;
             }
         }
 

--- a/index.js
+++ b/index.js
@@ -335,7 +335,11 @@ function getCommitData(gitPath, sha) {
             break;
           default:
             //should just be the commit message left
-            data.commitMessage = section;
+            if (!data.commitMessage) {
+              data.commitMessage = section
+            } else {
+              data.commitMessage = `${data.commitMessage}\n${section}`
+            }
         }
 
         return data;


### PR DESCRIPTION
`data.commitMessage` keeps getting overwritten for multiline commit messages. 

This change should fix that. 

Sorry if this PR is all sudden but I found no contributing guidelines. This change seemed easy enough so I went ahead with it. Let me know what you think @rwjblue 